### PR TITLE
Add Slack invite link

### DIFF
--- a/src/components/Main.astro
+++ b/src/components/Main.astro
@@ -2,6 +2,7 @@
 import { Image } from "astro:assets";
 import gflogo from '../img/going-functional.png';
 const { greeting = "Hello", name = "Astronaut" } = Astro.props;
+const slackInviteLink = "https://join.slack.com/t/goingfunctional/shared_invite/zt-31bjfeqw0-JIWxPvHE2y42FQV02iJyKQ";
 ---
 <div class="container">
   <Image class={"logo_img"} src={ gflogo } alt="logo"></Image>
@@ -11,7 +12,7 @@ const { greeting = "Hello", name = "Astronaut" } = Astro.props;
   workplace adoption, our goal is to ensure that functional programming has a
   bright future.</p>
   
-  <a href="https://forms.gle/RkJwqGysgjY5ghsw5" class="mt-3 join-button">Join Us</a>
+  <a href={ slackInviteLink } class="mt-3 join-button">Join Us</a>
 </div>
 <slot />
 


### PR DESCRIPTION
Apparently you can have Slack invite links that never expire. The docs state otherwise:

> On the free, Pro, and Business+ plans, members with permission to send invitations can also share an invite link. Each invite link is active for 30 days, and can be used by up to 400 people. If your invite link expires, [find an owner or admin](https://slack.com/help/articles/360003534892-Browse-people-and-user-groups-in-Slack#find-owners-and-admins) who can [manage invite links](https://slack.com/help/articles/360060363633-Manage-pending-invitations-and-invite-links-for-your-workspace#manage-invitation-links) in Slack.

... but if you create an invite link you can set its expiration time to "Never expires" 🤷‍♂️

![Screenshot 2025-03-13 at 06 39 49](https://github.com/user-attachments/assets/87fb6bea-c0ae-4eef-98b6-c9dc1030fc70)

This PR replaces the old Google Form link with a Slack invite link. IMO is a better solution than having people go through a Google Form (at least if we don't care about "vetting" new members)
